### PR TITLE
Added filter and code to open gopher URLs from external intents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,12 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+
+
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="gopher" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/MainActivity.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/MainActivity.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.design.widget.FloatingActionButton;
@@ -57,6 +58,16 @@ public class MainActivity extends AppCompatActivity
                     .add(this);
             new Bookmark(this, "SDF", "sdf.org").add(this);
             new Bookmark(this, "Khzae", "khzae.net").add(this);
+        }
+
+        Intent intent = getIntent();
+        if (Intent.ACTION_VIEW.equals(intent.getAction()))
+        {
+            Uri uri = intent.getData();
+            if (uri != null) {
+                Page page = Page.makePage(uri.toString());
+                page.open(this);
+            }
         }
     }
 


### PR DESCRIPTION
I noticed that PocketGopher does not open gopher URLs which are clicked for example in the web browser of the device. (Example webpage with gopher link: [https://mastodon.sdf.org/@julienxx/101671814876187041](https://mastodon.sdf.org/@julienxx/101671814876187041))

I have added a few lines to the manifest and to the MainActivity which register the app as a client for gopher URLs.