### PR TITLE
Fix crashes when parsing malformed menus

### DIFF
--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Connection.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Connection.java
@@ -127,9 +127,9 @@ public class Connection
                             linesplit[0].substring(1) //remove the type tag
                     ));
                 }
-                catch (NumberFormatException e)
+                catch (StringIndexOutOfBoundsException | NumberFormatException e)
                 {
-                    // the port is not a valid integer, add an unknown page
+                    // something went wrong, show an unknown page entry
                     response.add(new UnknownPage(line));
                 }
 

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Connection.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Connection.java
@@ -114,13 +114,25 @@ public class Connection
             }
             else
             {
-                response.add(Page.makePage(
-                        line.charAt(0), //type
-                        linesplit[1],
-                        linesplit[2],
-                        Integer.parseInt(linesplit[3]),
-                        linesplit[0].substring(1) //remove the type tag
-                ));
+                try
+                {
+                    // verify the port parses as an integer
+                    int port = Integer.parseInt(linesplit[3].trim());
+                    // add the response
+                    response.add(Page.makePage(
+                            line.charAt(0), //type
+                            linesplit[1],
+                            linesplit[2],
+                            port,
+                            linesplit[0].substring(1) //remove the type tag
+                    ));
+                }
+                catch (NumberFormatException e)
+                {
+                    // the port is not a valid integer, add an unknown page
+                    response.add(new UnknownPage(line));
+                }
+
             }
         }
 


### PR DESCRIPTION
Hi, this PR adds better exception handling to Connection.getMenu() resolving several crashes I have noticed in real-world gopher holes. It prevents crashes in at least the following cases:

- A menu line is missing the item type character
- A menu line port does not parse as an integer

In both cases the line is treated as an unknown page.