### PR TITLE
Various fixes to save-as dialog

### DIFF
--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
@@ -92,7 +92,6 @@ public abstract class Page implements Serializable
         input.setText(selector.substring(selector.lastIndexOf("/") + 1)); //default file name
         input.setTextAppearance(context, MainActivity.font);
         alertDialog.setView(input);
-        final String fileName = input.getText().toString();
 
         // create the handler for running UI code on main thread
         final Handler handler = new Handler(Looper.getMainLooper());
@@ -114,6 +113,7 @@ public abstract class Page implements Serializable
                                     Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).toString();
 
                                 //file is always saved in the download directory atm
+                                final String fileName = input.getText().toString();
                                 File file = new File(downloadDirectory + "/" + fileName);
 
                                 try

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
@@ -79,7 +79,7 @@ public abstract class Page implements Serializable
         }
 
         //AlertDialog to be shown when method gets called
-        AlertDialog.Builder alertDialog = new AlertDialog.Builder(context);
+        final AlertDialog.Builder alertDialog = new AlertDialog.Builder(context);
         alertDialog.setTitle("Save as:");
 
         //the EditText where the user will input the name of the file
@@ -94,6 +94,8 @@ public abstract class Page implements Serializable
         alertDialog.setView(input);
         final String fileName = input.getText().toString();
 
+        // create the handler for running UI code on main thread
+        final Handler handler = new Handler(Looper.getMainLooper());
 
         alertDialog.setPositiveButton("Save",
                 new DialogInterface.OnClickListener()
@@ -106,7 +108,6 @@ public abstract class Page implements Serializable
                             @Override
                             public void run()
                             {
-                                Handler handler = new Handler(Looper.getMainLooper());
 
                                 //file is always saved in the download directory atm
                                 File file = new File(
@@ -216,7 +217,15 @@ public abstract class Page implements Serializable
                 }
         );
 
-        alertDialog.show();
+        // show the alert dialog
+        handler.post(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                alertDialog.show();
+            }
+        });
     }
 
 

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
@@ -123,7 +123,7 @@ public abstract class Page implements Serializable
                                     {
                                         n += 1;
 
-                                        if (fileName.matches("(.*).(.*)"))
+                                        if (fileName.matches("(.*)\\.(.*)"))
                                         {
                                             file = new File(
                                                     Environment.getExternalStoragePublicDirectory

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
@@ -109,12 +109,12 @@ public abstract class Page implements Serializable
                             public void run()
                             {
 
+                                //get the downloads directory name
+                                final String downloadDirectory =
+                                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).toString();
+
                                 //file is always saved in the download directory atm
-                                File file = new File(
-                                        Environment.getExternalStoragePublicDirectory(Environment
-                                                .DIRECTORY_DOWNLOADS) +
-                                                "/" + fileName
-                                );
+                                File file = new File(downloadDirectory + "/" + fileName);
 
                                 try
                                 {
@@ -125,26 +125,16 @@ public abstract class Page implements Serializable
 
                                         if (fileName.matches("(.*)\\.(.*)"))
                                         {
-                                            file = new File(
-                                                    Environment.getExternalStoragePublicDirectory
-                                                            (Environment
-                                                                    .DIRECTORY_DOWNLOADS) +
-                                                            "/" + fileName.substring(0, fileName
-                                                            .indexOf
-                                                                    ('.')) +
+                                            file = new File(downloadDirectory + "/" +
+                                                            fileName.substring(0, fileName.indexOf('.')) +
                                                             "(" + String.valueOf(n) + ")" +
-                                                            fileName.substring(fileName.indexOf(
-                                                                    '.'))
+                                                            fileName.substring(fileName.indexOf('.'))
                                             );
                                         }
                                         else
                                         {
-                                            file = new File(
-                                                    Environment.getExternalStoragePublicDirectory
-                                                            (Environment
-                                                                    .DIRECTORY_DOWNLOADS) +
-                                                            fileName +
-                                                            "(" + String.valueOf(n) + ")"
+                                            file = new File(downloadDirectory + "/" +
+                                                            fileName + "(" + String.valueOf(n) + ")"
                                             );
                                         }
                                     }
@@ -179,7 +169,7 @@ public abstract class Page implements Serializable
                                         public void run()
                                         {
                                             Toast.makeText(context,
-                                                    "File saved saved as: " + f.getName(),
+                                                    "File saved as: " + f.getName(),
                                                     Toast.LENGTH_SHORT
                                             ).show();
                                         }


### PR DESCRIPTION
This PR makes fixes various issues with the save-as dialog. The issues previously encountered with the dialog were:

- Crashing in some circumstances due to string handling issues
- It was not respecting the file name entered by the user in input box
- It saved files in the home directory rather than the downloads directory