### PR TITLE
Disable textview autosizing and allow setting font size via dialog

### DIFF
--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/MainActivity.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/MainActivity.java
@@ -18,6 +18,7 @@ import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ListView;
+import android.widget.NumberPicker;
 
 import com.gmail.afonsotrepa.pocketgopher.gopherclient.Page;
 
@@ -28,7 +29,9 @@ public class MainActivity extends AppCompatActivity
 {
     private Menu menu;
     public static int font = R.style.monospace;
+    public static int fontSize = 14; // 14sp is the default textview text size
 
+    private static final String FONT_SIZE_SETTING = "font_size";
     private static final String MONOSPACE_FONT_SETTING = "monospace_font";
     private static final String FIRST_RUN = "first_run";
 
@@ -48,6 +51,8 @@ public class MainActivity extends AppCompatActivity
         {
             font = R.style.serif;
         }
+
+        fontSize = sharedPreferences.getInt(FONT_SIZE_SETTING, fontSize);
 
         if (sharedPreferences.getBoolean(FIRST_RUN, true))
         {
@@ -179,13 +184,15 @@ public class MainActivity extends AppCompatActivity
     @Override
     public boolean onOptionsItemSelected(MenuItem item)
     {
+        // get the preferences editor
+        final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        final SharedPreferences.Editor editor = sharedPreferences.edit();
+        // get a dialog builder
+        AlertDialog.Builder alertDialog = new AlertDialog.Builder(this);
+
         switch (item.getItemId())
         {
             case R.id.monospace_font:
-                SharedPreferences sharedPreferences = PreferenceManager
-                        .getDefaultSharedPreferences(this);
-                SharedPreferences.Editor editor = sharedPreferences.edit();
-
                 if (font == R.style.serif)
                 {
                     font = R.style.monospace;
@@ -205,9 +212,38 @@ public class MainActivity extends AppCompatActivity
 
                 return true;
 
+            case R.id.font_size:
+                //create the font size number picker
+                final NumberPicker numberPicker = new NumberPicker(this);
+                numberPicker.setMinValue(1);
+                numberPicker.setMaxValue(64);
+                numberPicker.setValue(sharedPreferences.getInt(FONT_SIZE_SETTING, 12));
+
+                //setup the dialog with the number picker
+                alertDialog.setMessage("Font Size");
+                alertDialog.setView(numberPicker);
+
+                //setup the ok button callback to save the number picker value into shared preferences
+                alertDialog.setPositiveButton("OK",
+                        new DialogInterface.OnClickListener()
+                        {
+                            @Override
+                            public void onClick(final DialogInterface dialog, int which)
+                            {
+                                // store the new font size setting into shared preferences
+                                editor.putInt(FONT_SIZE_SETTING, numberPicker.getValue());
+                                editor.apply();
+                            }
+                        }
+                );
+
+                // show the dialog
+                alertDialog.show();
+
+                return true;
+
             case R.id.link:
                 //create the dialog to be shown when the button gets clicked
-                AlertDialog.Builder alertDialog = new AlertDialog.Builder(this);
                 alertDialog.setMessage("URL:");
 
                 //setup the EditText where the user will input url to the page
@@ -219,7 +255,6 @@ public class MainActivity extends AppCompatActivity
                 input.setLayoutParams(layoutParams);
                 input.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
                 alertDialog.setView(input);
-
 
                 alertDialog.setPositiveButton("Go",
                         new DialogInterface.OnClickListener()

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/MainActivity.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/MainActivity.java
@@ -223,6 +223,8 @@ public class MainActivity extends AppCompatActivity
                 alertDialog.setMessage("Font Size");
                 alertDialog.setView(numberPicker);
 
+                final MainActivity activity = this;
+
                 //setup the ok button callback to save the number picker value into shared preferences
                 alertDialog.setPositiveButton("OK",
                         new DialogInterface.OnClickListener()
@@ -230,9 +232,13 @@ public class MainActivity extends AppCompatActivity
                             @Override
                             public void onClick(final DialogInterface dialog, int which)
                             {
+                                // get the new font size from number picker
+                                int newFontSize = numberPicker.getValue();
                                 // store the new font size setting into shared preferences
-                                editor.putInt(FONT_SIZE_SETTING, numberPicker.getValue());
+                                editor.putInt(FONT_SIZE_SETTING, newFontSize);
                                 editor.apply();
+                                // update the current font size
+                                activity.fontSize = newFontSize;
                             }
                         }
                 );

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Activity/MenuActivity.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Activity/MenuActivity.java
@@ -50,6 +50,7 @@ public class MenuActivity extends AppCompatActivity
 
         final TextView textView = findViewById(R.id.textView);
         textView.setTextAppearance(this, MainActivity.font);
+        textView.setTextSize(MainActivity.fontSize);
         textView.setMovementMethod(LinkMovementMethod.getInstance());
 
         final Context context = this;

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Activity/TextFileActivity.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Activity/TextFileActivity.java
@@ -49,6 +49,7 @@ public class TextFileActivity extends AppCompatActivity
         final TextView textView = (TextView) findViewById(R.id.textView);
         //set the font
         textView.setTextAppearance(this, MainActivity.font);
+        textView.setTextSize(MainActivity.fontSize);
 
         //start a new thread to do network stuff
         new Thread(new Runnable()

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/AudioPage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/AudioPage.java
@@ -78,7 +78,7 @@ public class AudioPage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/BinPage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/BinPage.java
@@ -70,7 +70,7 @@ public class BinPage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/HtmlPage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/HtmlPage.java
@@ -71,7 +71,7 @@ public class HtmlPage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/ImagePage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/ImagePage.java
@@ -80,7 +80,7 @@ public class ImagePage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/MenuPage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/MenuPage.java
@@ -73,7 +73,7 @@ public class MenuPage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG) , 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/Page.java
@@ -6,12 +6,14 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
+import android.graphics.drawable.Drawable;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.text.style.ImageSpan;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -55,6 +57,12 @@ public abstract class Page implements Serializable
         this(server, port, type, selector, null);
     }
 
+    public static ImageSpan formatIcon(Context context, TextView textView, int resourceID) {
+        Drawable icon = context.getDrawable(resourceID);
+        int iconSize = (int)((double)textView.getLineHeight()*2.5);
+        icon.setBounds(0, 0, iconSize, iconSize);
+        return new ImageSpan(icon, 0);
+    }
 
     public abstract void open(final Context context);
 

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/SearchPage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/SearchPage.java
@@ -73,7 +73,7 @@ public class SearchPage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/TextFilePage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/TextFilePage.java
@@ -69,7 +69,7 @@ public class TextFilePage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/UnknownPage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/UnknownPage.java
@@ -39,7 +39,7 @@ public class UnknownPage extends Page
             public void run()
             {
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 textView.append(text);
             }
         });

--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/VideoPage.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/gopherclient/VideoPage.java
@@ -79,7 +79,7 @@ public class VideoPage extends Page
                 text.setSpan(cs1, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 text.setSpan(cs2, 2, text.length() - 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 //set the image tag behind (left of) the text
-                text.setSpan(new ImageSpan(context, IMAGE_TAG), 0, 1, 0);
+                text.setSpan(Page.formatIcon(context, textView, IMAGE_TAG), 0, 1, 0);
                 //add it to the end of textView
                 textView.append(text);
             }

--- a/app/src/main/res/layout/activity_menu.xml
+++ b/app/src/main/res/layout/activity_menu.xml
@@ -24,7 +24,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_margin="16dp"
-                android:autoSizeTextType="uniform"
+                android:autoSizeTextType="none"
                 android:textIsSelectable="true"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/menu/client_main.xml
+++ b/app/src/main/res/menu/client_main.xml
@@ -11,6 +11,12 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/font_size"
+        android:title="Font size"
+        android:visible="true"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/link"
         android:enabled="true"
         android:icon="@drawable/ic_link_white"


### PR DESCRIPTION
This PR disables autosizing on TextViews, fixing problems I noted in [issue #13](https://github.com/afonsotrepa/PocketGopher/issues/13) and adds a "Font size" dialog allowing users to set their own font size with a number picker. The dialog is accessible from the main screen and is applied when viewing menus and text files. The page icons used on menus are also resized relative to the chosen font size/line height of the TextView. 