### PR TITLE
Urlencode bookmark URLs

### DIFF
--- a/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/Bookmark.java
+++ b/app/src/main/java/com/gmail/afonsotrepa/pocketgopher/Bookmark.java
@@ -17,6 +17,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -85,8 +87,8 @@ public class Bookmark
             );
 
             outputStream.write((
-                    this.name + "\t" +
-                            this.url + "\t" +
+                            this.name + "\t" +
+                            URLEncoder.encode(this.url, "UTF-8") + "\t" +
                             this.id.toString() + "\n"
             ).getBytes());
             outputStream.close();
@@ -121,7 +123,7 @@ public class Bookmark
                     //parse the bookmark
                     Bookmark bookmark = new Bookmark(
                             bsplit[0], //name
-                            bsplit[1], //url
+                            URLDecoder.decode(bsplit[1], "UTF-8"), //url
                             Integer.parseInt(bsplit[2]) //id
                     );
 


### PR DESCRIPTION
When bookmarking a page with a 'tab' character in the URL, PocketGopher will crash on startup and not start again until app data is cleared. This is because the bookmarks file is tab delimited, and the extra field causes an exception from parseInt. To prevent raw tab characters from ending up in the bookmarks file, this PR calls url encode/decode before reading/writing urls to the bookmarks file. This is also backwards compatible since URLDecode ignores special characters that would normally be url-encoded, so old bookmarks still work.